### PR TITLE
Tweaks, updates and fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "geforcenow",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -711,9 +711,9 @@
       }
     },
     "electron": {
-      "version": "10.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-10.0.0-beta.23.tgz",
-      "integrity": "sha512-jMav5NXZUN8YdcCfASy0Jimms3VoFEPa2nYGZTN/19nlryEedaZksHKJM9afVX3w9AnUv8xPCWdyXUQiRg0YWA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-10.1.0.tgz",
+      "integrity": "sha512-DyS6WhQ59+ZXQsI1EkpsYkOXFt0Xbp+mbxPTJS9A7O21r3JDzaTC+1Jxz7g6J+Sbi9Y7UFdRs0tn/vqhHJx2gA==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geforcenow",
   "appId": "com.electron.${name}",
-  "productName": "GeForce Now",
+  "productName": "GeForce NOW",
   "version": "1.0.2",
   "description": "A cross-platform web app for GeForce Now for ChromeBook",
   "main": "scripts/main.js",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
       "geforcenow-electron.desktop"
     ]
   },
-  "repository": "https://github.com/electron/geforcenow-electron",
+  "repository": "https://github.com/hmlendea/geforcenow-electron",
   "keywords": [
     "Electron",
     "gfn",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Horațiu Mlendea <Mlendea.Horatiu@GMail.com>",
   "license": "CC0-1.0",
   "devDependencies": {
-    "electron": "^10.0.0-beta.23",
-    "electron-builder": "^22.5.1"
+    "electron": "^10.0.0-beta.24",
+    "electron-builder": "^22.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "geforcenow",
   "appId": "com.electron.${name}",
   "productName": "GeForce NOW",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A cross-platform web app for GeForce Now for ChromeBook",
   "main": "scripts/main.js",
   "scripts": {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,4 @@
-const {app, BrowserWindow} = require('electron')
+const {app, globalShortcut, BrowserWindow} = require('electron')
 const path = require('path')
 const userAgent = 'Mozilla/5.0 (X11; CrOS x86_64 13099.85.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.110 Safari/537.36';
 
@@ -14,7 +14,7 @@ function createWindow () {
 
   mainWindow.loadURL('https://play.geforcenow.com');
   mainWindow.once('ready-to-show', () => {
-    mainWindow.show()
+    mainWindow.show();
   })
 }
 
@@ -22,11 +22,14 @@ app.whenReady().then(() => {
   createWindow()
   
   app.on('activate', function () {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
   })
+
+  // Prevent ESC from exiting fullscreen
+  globalShortcut.register('Esc', () => { });
 })
 
-app.on('browser-window-created',function(e,window) {
+app.on('browser-window-created', function(e, window) {
   window.setBackgroundColor('#1A1D1F');
   window.setMenu(null);
   window.webContents.setUserAgent(userAgent);
@@ -41,5 +44,6 @@ app.on('browser-window-created',function(e,window) {
 });
 
 app.on('window-all-closed', function () {
-  if (process.platform !== 'darwin') app.quit()
+  if (process.platform !== 'darwin')
+    app.quit();
 })

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4,8 +4,6 @@ const userAgent = 'Mozilla/5.0 (X11; CrOS x86_64 13099.85.0) AppleWebKit/537.36 
 
 function createWindow () {
   const mainWindow = new BrowserWindow({
-    width: 1280,
-    height: 768,
     show: false,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js')


### PR DESCRIPTION
 - Renamed the app title to use the correct casing (`GeForce **NOW**`)
 - Prevent the `Esc` key from exiting fullscreen
 - Start the app maximised by default
 - Fixed the repository URL
 - Updated `electron` and `electron-builder`