### PR TITLE
Support for AppImage, deb, apk and snap

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,13 @@
   },
   "build": {
     "linux": {
-      "target": "zip",
+      "target": [
+        "zip",
+        "AppImage",
+        "deb",
+        "apk",
+        "snap"
+      ],
       "category": "Games",
       "artifactName": "${name}_${version}_linux.${ext}"
     },


### PR DESCRIPTION
This PR adds some build instruction for the electron builder.

**It adds the following targets:**

**AppImage**: For distribution with one big binary, that can be opened without installation.
**deb**: For installing it on Debian/Ubuntu
**apk**: For installing it on Alpine Linux
**Snap**: For installing it on many Distributions like Ubuntu

I tested the build process and it runs great.
I tested the AppImage and deb version by using them. The others should be fine.

AppImage, deb and apk should be distributed by adding them to the release files on github.
The Snap needs to be uploaded to [snapcraft](https://snapcraft.io/). It should be fairly simple. Heres a [tutorial](https://snapcraft.io/docs/releasing-your-app).

It would probably be a good idea to add a logo, because otherwise the electron logo gets used.

closes: #9 