### PR TITLE
Gamepad and security patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geforcenow",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "geforcenow",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "CC0-1.0",
       "devDependencies": {
         "electron": "12.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2381,9 +2381,9 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -5368,9 +5368,9 @@
       }
     },
     "normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
     },
     "npm-conf": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "geforcenow",
   "appId": "com.electron.${name}",
   "productName": "GeForce NOW",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A Linux desktop web app for GeForce NOW",
   "main": "scripts/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,12 @@
       "category": "Games",
       "artifactName": "${name}_${version}_linux.${ext}"
     },
+    "snap": {
+      "plugs": [
+        "default",
+        "joystick"
+      ]
+    },
     "extraFiles": [
       "geforcenow-electron.desktop"
     ]


### PR DESCRIPTION
 - Updated the `normalize-url` dependency _(1)_
 - Added the `joystick` plug to the snap build _(2)_

_(1)_: Fixes a high severity security vulnerability
_(2)_: Hopefully fixes the gamepads not working on the snap version